### PR TITLE
Fix for path extraction or webdav client cant find path to sync

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -966,7 +966,9 @@ class WebDavXmlUtils:
                 urn = unquote(href)
 
                 if path[-1] == Urn.separate:
-                    if not path == urn:
+                    # remove / from path to compare with urn
+                    # e.g. /path = /path
+                    if not path[:-1] == urn:
                         continue
                 else:
                     path_with_sep = "{path}{sep}".format(path=path, sep=Urn.separate)


### PR DESCRIPTION
Без этой правки все время получаю ошибку:
```
Traceback (most recent call last):
  File "syncdav.py", line 17, in <module>
    status = client.pull(remote_directory='ivr/', local_directory='/tmp/ivr/')
  File "/home/vitaliy/work/python3/lib/python3.5/site-packages/webdav3/client.py", line 691, in pull
    if not self.is_dir(urn.path()):
  File "/home/vitaliy/work/python3/lib/python3.5/site-packages/webdav3/client.py", line 69, in _wrapper
    res = fn(self, *args, **kw)
  File "/home/vitaliy/work/python3/lib/python3.5/site-packages/webdav3/client.py", line 593, in is_dir
    return WebDavXmlUtils.parse_is_dir_response(content=response.content, path=path, hostname=self.webdav.hostname)
  File "/home/vitaliy/work/python3/lib/python3.5/site-packages/webdav3/client.py", line 888, in parse_is_dir_response
    response = WebDavXmlUtils.extract_response_for_path(content=content, path=path, hostname=hostname)
  File "/home/vitaliy/work/python3/lib/python3.5/site-packages/webdav3/client.py", line 981, in extract_response_for_path
    raise RemoteResourceNotFound(path)
webdav3.exceptions.RemoteResourceNotFound: Remote resource: /ivr/ not found
```

То есть при сравнении директорий не находит папки, так как:
/path/ != /path