### PR TITLE
Fix wrong argument for resource creation.

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -644,7 +644,7 @@ class Client(object):
 
     def resource(self, remote_path):
         urn = Urn(remote_path)
-        return Resource(self, urn.path())
+        return Resource(self, urn)
 
     def push(self, remote_directory, local_directory):
 


### PR DESCRIPTION
Within the resource class its asumed that urn is a Urn instance and not
a str. Unwrapping the path here gives an exception at least in
write_to().

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>