### PR TITLE
fixed missing requirement; incorrect import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     version=version,
     packages=find_packages(),
     requires=['python (>= 2.7.6)'],
-    install_requires=['requests', 'lxml'],
+    install_requires=['requests', 'lxml', 'argcomplete'],
     scripts=['wdc'],
     tests_require=['pytest', 'pyhamcrest', 'junit-xml', 'pytest-allure-adaptor'],
     cmdclass={'install': Install, 'test': Test},

--- a/wdc
+++ b/wdc
@@ -306,7 +306,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog='wdc', formatter_class=Formatter, epilog=epilog, usage=usage)
     parser.add_argument("action", help=actions_help, choices=actions)
 
-    from webdav.client import __version__ as version
+    from webdav3.client import __version__ as version
     version_text = "{name} {version}".format(name="%(prog)s", version=version)
     parser.add_argument("-v", '--version', action='version', version=version_text)
     parser.add_argument("-r", "--root", help="example: dir1/dir2")


### PR DESCRIPTION
I found a few problems with wdc:
- argcomplete is required to run wdc but was not included in the requirements;
- wdc tries to import webdav instead of webdav3.

This is my first pull request, so if I do anything wrong please let me know.