### PR TITLE
Added verify attribute to execute_request method

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -86,6 +86,9 @@ class Client(object):
     # request timeout in seconds
     timeout = 30
 
+    # controls whether to verify the server's TLS certificate or not
+    verify = True
+
     # HTTP headers for different actions
     http_header = {
         'list': ["Accept: */*", "Depth: 1"],
@@ -159,7 +162,8 @@ class Client(object):
             headers=self.get_headers(action, headers_ext),
             timeout=self.timeout,
             data=data,
-            stream=True
+            stream=True,
+            verify=self.verify
         )
         if response.status_code == 507:
             raise NotEnoughSpace()


### PR DESCRIPTION
To be able to control whether to verify the server's TLS certificate
or not, the verify attribute has been added to the execute_request
method.