### PR TITLE
WIP: Disable client.check by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.7"
 install:
   - python setup.py develop
 script:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,11 @@ class Test(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
+try:
+    long_description = open('README.rst', encoding="utf-8").read()
+except TypeError:
+    long_description = open('README.rst').read()
+
 setup(
     name='webdavclient3',
     version=version,
@@ -53,7 +58,7 @@ setup(
     cmdclass={'install': Install, 'test': Test},
     description='WebDAV client, based on original package https://github.com/designerror/webdav-client-python but '
                 'uses requests instead of PyCURL',
-    long_description=open('README.rst').read(),
+    long_description=long_description,
     author='Evgeny Ezhov',
     author_email='ezhov.evgeny@gmail.com',
     url='https://github.com/ezhov-evgeny/webdav-client-python-3',

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -167,6 +167,10 @@ class Client(object):
         )
         if response.status_code == 507:
             raise NotEnoughSpace()
+        if response.status_code == 404:
+            raise RemoteResourceNotFound(path=path)
+        if response.status_code == 405:
+            raise MethodNotSupported(name=action, server=hostname)
         if response.status_code >= 400:
             raise ResponseErrorCode(url=self.get_url(path), code=response.status_code, message=response.content)
         return response
@@ -270,6 +274,9 @@ class Client(object):
         :param remote_path: (optional) path to resource on WebDAV server. Defaults is root directory of WebDAV.
         :return: True if resource is exist or False otherwise
         """
+
+        if not self.webdav.do_check:
+            return True
         urn = Urn(remote_path)
         try:
             response = self.execute_request(action='check', path=urn.quote())

--- a/webdav3/connection.py
+++ b/webdav3/connection.py
@@ -22,7 +22,7 @@ class WebDAVSettings(ConnectionSettings):
     ns = "webdav:"
     prefix = "webdav_"
     keys = {'hostname', 'login', 'password', 'token', 'root', 'cert_path', 'key_path', 'recv_speed', 'send_speed',
-            'verbose'}
+            'verbose', 'do_check'}
 
     hostname = None
     login = None
@@ -34,6 +34,7 @@ class WebDAVSettings(ConnectionSettings):
     recv_speed = None
     send_speed = None
     verbose = None
+    do_check = False
 
     def __init__(self, options):
 

--- a/webdav3/exceptions.py
+++ b/webdav3/exceptions.py
@@ -55,7 +55,7 @@ class MethodNotSupported(WebDavException):
         self.server = server
 
     def __str__(self):
-        return "Method {name} not supported for {server}".format(name=self.name, server=self.server)
+        return "Method '{name}' not supported for {server}".format(name=self.name, server=self.server)
 
 
 class ConnectionException(WebDavException):


### PR DESCRIPTION
Some of my webdav services do not support `check` operation, see https://github.com/kamikaze/webdav/issues/5.

When that is the case, All operations related to `check` will fail since `check` always return `False`. For example, `list(sub-directories)`, and `mkdir` at any location(including root).

Also,  `check` action will be a potential reason for being blocked by some services as it is counted by rate limiting, since `check` is done by a request to the server.

There are some problems with my patch so this is not supposed to be merged currently. Will try to update and test when I have time.