### PR TITLE
Stripping suburl from paths in extract_response_for_path

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -963,6 +963,8 @@ class WebDavXmlUtils:
         print("content", content)
         print("path", path)
         print("hostname", hostname)
+        from urllib.parse import urlparse
+        prefix = urlparse(hostname).path
         try:
             tree = etree.fromstring(content)
             print("tree", tree)
@@ -976,6 +978,9 @@ class WebDavXmlUtils:
                 print("href", href)
 
                 if Urn.compare_path(n_path, href) is True:
+                    return resp
+                href_without_prefix = href[len(prefix):] if href.startswith(prefix) else href
+                if Urn.compare_path(n_path, href_without_prefix) is True:
                     return resp
             raise RemoteResourceNotFound(path)
         except etree.XMLSyntaxError:

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -959,14 +959,21 @@ class WebDavXmlUtils:
         :param hostname: the server hostname.
         :return: XML object of response for the remote resource defined by path.
         """
+        print("extract_response_for_path called")
+        print("content", content)
+        print("path", path)
+        print("hostname", hostname)
         try:
             tree = etree.fromstring(content)
+            print("tree", tree)
             responses = tree.findall("{DAV:}response")
-
+            print("responses", responses)
             n_path = Urn.normalize_path(path)
-
+            print("n_path", n_path)
             for resp in responses:
                 href = resp.findtext("{DAV:}href")
+                print("resp", resp)
+                print("href", href)
 
                 if Urn.compare_path(n_path, href) is True:
                     return resp

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -16,10 +16,10 @@ from webdav3.exceptions import *
 from webdav3.urn import Urn
 
 try:
-    from urllib.parse import unquote, urlsplit
+    from urllib.parse import unquote, urlsplit, urlparse
 except ImportError:
     from urllib import unquote
-    from urlparse import urlsplit
+    from urlparse import urlsplit, urlparse
 
 __version__ = "0.2"
 log = logging.getLogger(__name__)
@@ -959,23 +959,14 @@ class WebDavXmlUtils:
         :param hostname: the server hostname.
         :return: XML object of response for the remote resource defined by path.
         """
-        print("extract_response_for_path called")
-        print("content", content)
-        print("path", path)
-        print("hostname", hostname)
-        from urllib.parse import urlparse
         prefix = urlparse(hostname).path
         try:
             tree = etree.fromstring(content)
-            print("tree", tree)
             responses = tree.findall("{DAV:}response")
-            print("responses", responses)
             n_path = Urn.normalize_path(path)
-            print("n_path", n_path)
+
             for resp in responses:
                 href = resp.findtext("{DAV:}href")
-                print("resp", resp)
-                print("href", href)
 
                 if Urn.compare_path(n_path, href) is True:
                     return resp

--- a/webdav3/urn.py
+++ b/webdav3/urn.py
@@ -64,4 +64,9 @@ class Urn(object):
     @staticmethod
     def compare_path(path_a, href):
         unqouted_path = Urn.separate + unquote(urlsplit(href).path)
+        print("path_a", path_a)
+        print("href", href)
+        print("unqouted_path", unqouted_path)
+        print("path_a(normalized)", Urn.normalize_path(path_a))
+        print("unqouted_path(normalized)", Urn.normalize_path(unqouted_path))
         return Urn.normalize_path(path_a) == Urn.normalize_path(unqouted_path)

--- a/webdav3/urn.py
+++ b/webdav3/urn.py
@@ -64,9 +64,4 @@ class Urn(object):
     @staticmethod
     def compare_path(path_a, href):
         unqouted_path = Urn.separate + unquote(urlsplit(href).path)
-        print("path_a", path_a)
-        print("href", href)
-        print("unqouted_path", unqouted_path)
-        print("path_a(normalized)", Urn.normalize_path(path_a))
-        print("unqouted_path(normalized)", Urn.normalize_path(unqouted_path))
         return Urn.normalize_path(path_a) == Urn.normalize_path(unqouted_path)


### PR DESCRIPTION
When accessing a server on a suburl, such as, an Alfresco WebDav:
* http://172.17.0.8:8080/alfresco/webdav
The file paths procssed by `extract_response_for_path`, specifically `href` contains the suburl as a prefix, for instance:
* `/alfresco/webdav/Sites/` rather than just `Sites/`.

I am not sure if this is a specific problem with Alfresco WebDav, or a common issue.
Either way, the provided code fixes this issue by removing the suburl from paths, if it exists.