### PR TITLE
remove a costy is_dir-check on obvious directories to speed up a pull

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -687,6 +687,8 @@ class Client(object):
         def prune(src, exp):
             return [sub(exp, "", item) for item in src]
 
+        updated=False
+
         urn = Urn(remote_directory, directory=True)
 
         ## here we check for the current directory
@@ -715,6 +717,7 @@ class Client(object):
             ## no need to check it here
             if remote_urn.path().endswith("/"):
                 if not os.path.exists(local_path):
+                    updated=True
                     os.mkdir(local_path)
                 ## nevertheless, since we pull the directory, it will be checked up there
                 self.pull(remote_directory=remote_path, local_directory=local_path)
@@ -722,6 +725,8 @@ class Client(object):
                 if remote_resource_name in local_resource_names:
                     continue
                 self.download_file(remote_path=remote_path, local_path=local_path)
+                updated=True
+        return updated
 
     def sync(self, remote_directory, local_directory):
 

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -689,6 +689,7 @@ class Client(object):
 
         urn = Urn(remote_directory, directory=True)
 
+        ## here we check for the current directory
         if not self.is_dir(urn.path()):
             raise OptionNotValid(name="remote_path", value=remote_directory)
 
@@ -697,6 +698,7 @@ class Client(object):
 
         local_resource_names = listdir(local_directory)
 
+        ## here we get all files and directories in the current directory
         paths = self.list(urn.path())
         expression = "{begin}{end}".format(begin="^", end=remote_directory)
         remote_resource_names = prune(paths, expression)
@@ -709,9 +711,12 @@ class Client(object):
 
             remote_urn = Urn(remote_path)
 
-            if self.is_dir(remote_urn.path()):
+            ## if the string ends with an "/" it *must* be a directory
+            ## no need to check it here
+            if remote_urn.path().endswith("/"):
                 if not os.path.exists(local_path):
                     os.mkdir(local_path)
+                ## nevertheless, since we pull the directory, it will be checked up there
                 self.pull(remote_directory=remote_path, local_directory=local_path)
             else:
                 if remote_resource_name in local_resource_names:


### PR DESCRIPTION
Hi there, 

the "pull" seemed to take ages with my setup, since every is_dir check takes up to one second.
For the files this is not necessary. I included some comments to make this clearer.
and:
https://tools.ietf.org/html/rfc2518#section-5.1
to make clear, that "/" has to be a directory-ending

I have not thought this through with push or any other method and I only checked this with my setup. Nevertheless you might want to give it a thought.

Cheers.