### PR TITLE
Add Oauth2 Bearer Token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ res1.write_async(local_path="~/Downloads/file1", callback)
 
 Release Notes
 -------------
+**Version 3.14.1**
+ * Fixed issue during coping and moving files with cyrillic names
+
 **Version 3.14**
  * Override methods for customizing communication with WebDAV servers
  * Support multiple clients simultaneously

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Release Notes
 -------------
 **Version 3.14.1**
  * Fixed issue during coping and moving files with cyrillic names
+ * Support OAuth2 bearer tokens by https://github.com/danielloader
 
 **Version 3.14**
  * Override methods for customizing communication with WebDAV servers

--- a/tests/base_client_it.py
+++ b/tests/base_client_it.py
@@ -13,6 +13,7 @@ class BaseClientTestCase(unittest.TestCase):
     remote_path_dir = 'test_dir'
     remote_path_dir2 = 'test_dir2'
     remote_inner_path_dir = 'test_dir/inner'
+    inner_dir_name = 'inner'
     local_base_dir = 'tests/'
     local_file = 'test.txt'
     local_file_path = local_base_dir + 'test.txt'

--- a/tests/test_client_it.py
+++ b/tests/test_client_it.py
@@ -208,10 +208,10 @@ class ClientTestCase(BaseClientTestCase):
         self._prepare_for_downloading(True)
         self.client.pull(self.remote_path_dir, self.local_path_dir)
         self.assertTrue(path.exists(self.local_path_dir), 'Expected the directory is downloaded.')
-        self.assertTrue(path.exists(self.local_path_dir + os.path.sep + 'inner'), 'Expected the directory is downloaded.')
-        self.assertTrue(path.exists(self.local_path_dir + os.path.sep + 'inner'), 'Expected the directory is downloaded.')
+        self.assertTrue(path.exists(self.local_path_dir + os.path.sep + self.inner_dir_name), 'Expected the directory is downloaded.')
+        self.assertTrue(path.exists(self.local_path_dir + os.path.sep + self.inner_dir_name), 'Expected the directory is downloaded.')
         self.assertTrue(path.isdir(self.local_path_dir), 'Expected this is a directory.')
-        self.assertTrue(path.isdir(self.local_path_dir + os.path.sep + 'inner'), 'Expected this is a directory.')
+        self.assertTrue(path.isdir(self.local_path_dir + os.path.sep + self.inner_dir_name), 'Expected this is a directory.')
         self.assertTrue(path.exists(self.local_path_dir + os.path.sep + self.local_file),
                         'Expected the file is downloaded')
         self.assertTrue(path.isfile(self.local_path_dir + os.path.sep + self.local_file),

--- a/tests/test_cyrilic_client_it.py
+++ b/tests/test_cyrilic_client_it.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+from tests.test_client_it import ClientTestCase
+
+
+class MultiClientTestCase(ClientTestCase):
+    remote_path_file = 'директория/тестовый.txt'
+    remote_path_file2 = 'директория/тестовый2.txt'
+    remote_inner_path_file = 'директория/вложенная/тестовый.txt'
+    remote_path_dir = 'директория'
+    remote_path_dir2 = 'директория2'
+    remote_inner_path_dir = 'директория/вложенная'
+    inner_dir_name = 'вложенная'
+    local_base_dir = 'tests/'
+    local_file = 'тестовый.txt'
+    local_file_path = local_base_dir + 'тестовый.txt'
+    local_path_dir = local_base_dir + 'res/директория'
+    pulled_file = local_path_dir + os.sep + local_file
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/тестовый.txt
+++ b/tests/тестовый.txt
@@ -1,0 +1,1 @@
+test content for testing of webdav client

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -535,7 +535,7 @@ class Client(object):
             raise RemoteParentNotFound(urn_to.path())
 
         headers = [
-            "Destination: {url}".format(url=self.get_url(urn_to))
+            "Destination: {url}".format(url=self.get_url(urn_to.quote()))
         ]
         if self.is_dir(urn_from.path()):
             headers.append("Depth: {depth}".format(depth=depth))
@@ -558,7 +558,7 @@ class Client(object):
         if not self.check(urn_to.parent()):
             raise RemoteParentNotFound(urn_to.path())
 
-        header_destination = "Destination: {path}".format(path=self.get_url(urn_to))
+        header_destination = "Destination: {path}".format(path=self.get_url(urn_to.quote()))
         header_overwrite = "Overwrite: {flag}".format(flag="T" if overwrite else "F")
         self.execute_request(action='move', path=urn_from.quote(), headers_ext=[header_destination, header_overwrite])
 

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -177,7 +177,7 @@ class Client(object):
             headers.extend(headers_ext)
 
         if self.webdav.token:
-            webdav_token = "Authorization: OAuth {token}".format(token=self.webdav.token)
+            webdav_token = "Authorization: Bearer {token}".format(token=self.webdav.token)
             headers.append(webdav_token)
         return dict([map(lambda s: s.strip(), i.split(':', 1)) for i in headers])
 
@@ -211,16 +211,27 @@ class Client(object):
         """
         if self.session.auth:
             self.session.request(method="GET", url=self.webdav.hostname, verify=self.verify)  # (Re)Authenticates against the proxy
-        response = self.session.request(
-            method=self.requests[action],
-            url=self.get_url(path),
-            auth=(self.webdav.login, self.webdav.password),
-            headers=self.get_headers(action, headers_ext),
-            timeout=self.timeout,
-            data=data,
-            stream=True,
-            verify=self.verify
-        )
+        if all([self.webdav.login, self.webdav.password]) is False:
+            response = self.session.request(
+                method=self.requests[action],
+                url=self.get_url(path),
+                headers=self.get_headers(action, headers_ext),
+                timeout=self.timeout,
+                data=data,
+                stream=True,
+                verify=self.verify
+            )
+        else:
+            response = self.session.request(
+                method=self.requests[action],
+                url=self.get_url(path),
+                auth=(self.webdav.login, self.webdav.password),
+                headers=self.get_headers(action, headers_ext),
+                timeout=self.timeout,
+                data=data,
+                stream=True,
+                verify=self.verify
+            )
         if response.status_code == 507:
             raise NotEnoughSpace()
         if response.status_code == 404:

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -211,27 +211,16 @@ class Client(object):
         """
         if self.session.auth:
             self.session.request(method="GET", url=self.webdav.hostname, verify=self.verify)  # (Re)Authenticates against the proxy
-        if all([self.webdav.login, self.webdav.password]) is False:
-            response = self.session.request(
-                method=self.requests[action],
-                url=self.get_url(path),
-                headers=self.get_headers(action, headers_ext),
-                timeout=self.timeout,
-                data=data,
-                stream=True,
-                verify=self.verify
-            )
-        else:
-            response = self.session.request(
-                method=self.requests[action],
-                url=self.get_url(path),
-                auth=(self.webdav.login, self.webdav.password),
-                headers=self.get_headers(action, headers_ext),
-                timeout=self.timeout,
-                data=data,
-                stream=True,
-                verify=self.verify
-            )
+        response = self.session.request(
+            method=self.requests[action],
+            url=self.get_url(path),
+            auth=(self.webdav.login, self.webdav.password) if not self.webdav.token else None,
+            headers=self.get_headers(action, headers_ext),
+            timeout=self.timeout,
+            data=data,
+            stream=True,
+            verify=self.verify
+        )
         if response.status_code == 507:
             raise NotEnoughSpace()
         if response.status_code == 404:


### PR DESCRIPTION
Basic implementation of authenticating with token instead of basic auth, as the auth=(login,password) flag on requests sends junk authentication as it overrides the bearer authentication header with a base64 encoded blank string.