### PR TITLE
A Session's auth isn't used during the request

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -214,7 +214,7 @@ class Client(object):
         response = self.session.request(
             method=self.requests[action],
             url=self.get_url(path),
-            auth=(self.webdav.login, self.webdav.password) if not self.webdav.token else None,
+            auth=(self.webdav.login, self.webdav.password) if (not self.webdav.token and not self.session.auth) else None,
             headers=self.get_headers(action, headers_ext),
             timeout=self.timeout,
             data=data,


### PR DESCRIPTION
Hello,

I want to use the library to connect to a WebDAV server on a cRIO from National Instruments. At first I had problems connecting to it. It always returns that the authentication is forbidden.
After some reverse engineering I've found that the device requires HTTPDigestAuth.

So I set the ```client.session.auth``` directly to the HTTPDigestAuth as described in the README but the authentication still won't work.

My calling code looks like below:

```python
from webdav3.client import Client
from requests.auth import HTTPDigestAuth

options = {
    'webdav_hostname': 'http://HOSTNAME/files',
    'webdav_login': 'USERNAME',
    'webdav_password': 'PASSWORD'
}

client = Client(options)
client.session.auth = HTTPDigestAuth(options['webdav_login'], options['webdav_password'])
files = client.list()
print(files)
```

I found out that the auth is explicitly set to HTTPBasicAuth during the ```execute_request``` call. Therefore the session's auth was ignored during the merge process. 

My pull request checks explicitly a session's auth and will set the parameter of the session's request to None. This allows the requests library to use the already set session's auth.

Greets,
Martin