### PR TITLE
Fixes ezhov-evgeny#43 - local certificate options ignored

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -217,6 +217,7 @@ class Client(object):
             auth=(self.webdav.login, self.webdav.password) if (not self.webdav.token and not self.session.auth) else None,
             headers=self.get_headers(action, headers_ext),
             timeout=self.timeout,
+            cert=(self.webdav.cert_path, self.webdav.key_path) if (self.webdav.cert_path and self.webdav.key_path) else None,
             data=data,
             stream=True,
             verify=self.verify


### PR DESCRIPTION
If the webdav_cert_path and webdav_key_path options are set, they
should be passed to the call to requests in Client.execute_request
as the cert parameter.