### PR TITLE
Bugfix/duplicate path segments

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -715,6 +715,8 @@ class Client(object):
         remote_resource_names = prune(paths, expression)
 
         for remote_resource_name in remote_resource_names:
+            if remote_resource_name == "":
+                continue
             local_path = os.path.join(local_directory, remote_resource_name)
             remote_path = "{remote_directory}{resource_name}".format(remote_directory=urn.path(), resource_name=remote_resource_name)
             remote_urn = Urn(remote_path)

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -360,6 +360,8 @@ class Client(object):
         os.makedirs(local_path)
 
         for resource_name in self.list(urn.path()):
+            if urn.path().endswith(resource_name):
+                continue
             _remote_path = "{parent}{name}".format(parent=urn.path(), name=resource_name)
             _local_path = os.path.join(local_path, resource_name)
             self.download(local_path=_local_path, remote_path=_remote_path, progress=progress)

--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -715,7 +715,7 @@ class Client(object):
         remote_resource_names = prune(paths, expression)
 
         for remote_resource_name in remote_resource_names:
-            if remote_resource_name == "":
+            if urn.path().endswith(remote_resource_name):
                 continue
             local_path = os.path.join(local_directory, remote_resource_name)
             remote_path = "{remote_directory}{resource_name}".format(remote_directory=urn.path(), resource_name=remote_resource_name)


### PR DESCRIPTION
Works around an issue mentioned in #55 that seems to be triggered by the last path segment in the remote path that gets appended again at some point. Could not figure out the root cause yet.
Noticed in `pull` and `download_sync`.