### PR TITLE
Added option to specify chunk size

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -334,7 +334,7 @@ class Client(object):
             raise RemoteResourceNotFound(urn.path())
 
         response = self.execute_request(action='download', path=urn.quote())
-        for chunk in response.iter_content(chunk_size=128):
+        for chunk in response.iter_content(chunk_size=self.webdav.chunk_size):
             buff.write(chunk)
 
     def download(self, remote_path, local_path, progress=None):
@@ -396,7 +396,7 @@ class Client(object):
 
         with open(local_path, 'wb') as local_file:
             response = self.execute_request('download', urn.quote())
-            for block in response.iter_content(1024):
+            for block in response.iter_content(chunk_size=self.webdav.chunk_size):
                 local_file.write(block)
 
     def download_sync(self, remote_path, local_path, callback=None):

--- a/webdav3/connection.py
+++ b/webdav3/connection.py
@@ -25,7 +25,7 @@ class WebDAVSettings(ConnectionSettings):
     ns = "webdav:"
     prefix = "webdav_"
     keys = {'hostname', 'login', 'password', 'token', 'root', 'cert_path', 'key_path', 'recv_speed', 'send_speed',
-            'verbose', 'disable_check', 'override_methods', 'timeout'}
+            'verbose', 'disable_check', 'override_methods', 'timeout', 'chunk_size'}
 
     def __init__(self, options):
         self.hostname = None
@@ -41,6 +41,7 @@ class WebDAVSettings(ConnectionSettings):
         self.disable_check = False
         self.override_methods = {}
         self.timeout = 30
+        self.chunk_size = 65536
 
         self.options = dict()
 


### PR DESCRIPTION
This PR changes the default chunk_size to 64K. This value was determined by timing a series of downloads of a ~345MB file with different chunk sizes on a high-speed network, and 64K seems to yield the best balance between CPU and memory usage (please see table below for experiment data). This same chunk size is also used by [Galaxy](https://github.com/galaxyproject/galaxy/blob/327f58fd6bef2976e3c31a57b57ac319e24db407/lib/galaxy/util/__init__.py#L81), which adds a further data point that this is a good chunk size. This PR also adds an option to specify a custom chunk size if needed.

<table>
<thead><tr><th></th><th colspan=8>Python</th><th colspan=2>cURL</th></tr></thead><tbody>
 <tr><td>&nbsp;</td><td colspan=4>Execution time (seconds)</td><td colspan=4>CPU Usage (percentage)</td><td>Execution Time</td><td>CPU Usage</td></tr>
 <tr><td>Buffer Size</td><td>1k</td><td>64k</td><td>1MB</td><td>10MB</td><td>1k</td><td>64k</td><td>1MB</td><td>10MB</td><td>&nbsp;</td><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
 <tr><td>run1</td><td>11.56</td><td>3.36</td><td>2.81</td><td>3.42</td><td>74</td><td>38</td><td>45</td><td>34</td><td>3.65</td><td>25</td></tr>
 <tr><td>run2</td><td>11.06</td><td>2.85</td><td>2.7</td><td>4.21</td><td>78</td><td>46</td><td>41</td><td>29</td><td>3.2</td><td>28</td></tr>
 <tr><td>run3</td><td>12.67</td><td>3.08</td><td>3.14</td><td>3.59</td><td>75</td><td>44</td><td>42</td><td>34</td><td>3.58</td><td>25</td></tr>
 <tr><td>average</td><td>11.76</td><td>3.10</td><td>2.88</td><td>3.74</td><td>76</td><td>43</td><td>43</td><td>32</td><td>3.48</td><td>26</td></tr>
</tbody></table>