### PR TITLE
Excluding tests directory from a setup package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ except TypeError:
 setup(
     name='webdavclient3',
     version=version,
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     requires=['python (>= 3.3.0)'],
     install_requires=['requests', 'lxml', 'python-dateutil'],
     scripts=['wdc'],


### PR DESCRIPTION
My tests do not work correctly because when installing the webdavclient3 package, the directory tests is copied to the site-package folder.