### PR TITLE
Support for WebDAV lock

### DIFF
--- a/webdav3/exceptions.py
+++ b/webdav3/exceptions.py
@@ -100,3 +100,11 @@ class NotEnoughSpace(WebDavException):
 
     def __str__(self):
         return self.message
+
+
+class ResourceLocked(WebDavException):
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        return "Resource {path} locked".format(path=self.path)


### PR DESCRIPTION
This change adds support for WebDAV locks (see http://webdav.org/specs/rfc4918.html#METHOD_LOCK).
This only implements the bare minimum of an exclusive write lock.

Usage:
```python
with client.lock("path") as c:
    c.mkdir("path/dir")
    c.upload_file("path/file", "local/file")
```