### PR TITLE
Added missing parameter 'progress' in upload method

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -569,7 +569,7 @@ class Client(object):
             self.upload_directory(local_path=local_path, remote_path=remote_path, progress=progress,
                                   progress_args=progress_args)
         else:
-            self.upload_file(local_path=local_path, remote_path=remote_path, progress_args=progress_args)
+            self.upload_file(local_path=local_path, remote_path=remote_path, progress=progress, progress_args=progress_args)
 
     def upload_directory(self, remote_path, local_path, progress=None, progress_args=()):
         """Uploads directory to remote path on WebDAV server.


### PR DESCRIPTION
Added missing  parameter 'progress' to upload function. With the parameter missing, to callback is done to show the current upload status. 

e.g. when calling `client.upload_sync(remote_path=target, local_path=source, progress=progress_update` to function `def progress_update(..)` is not being called. 