### PR TITLE
Don't catch ResponseErrorCode

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -301,8 +301,6 @@ class Client(object):
             response = self.execute_request(action='check', path=urn.quote())
         except RemoteResourceNotFound:
             return False
-        except ResponseErrorCode:
-            return False
 
         if int(response.status_code) == 200:
             return True


### PR DESCRIPTION
Hello,
What are your thoughts on this idea? I think that catching the `ResponseErrorCode` obscures errors that the user would want to be aware of, such as `401` errors.

Btw, as far as Github etiquette goes, is this a good way to start such a discussion?