### PR TITLE
mark Urn.expression as a regex

### DIFF
--- a/webdav3/urn.py
+++ b/webdav3/urn.py
@@ -8,7 +8,7 @@ class Urn(object):
     def __init__(self, path, directory=False):
 
         self._path = quote(path)
-        expressions = "/\.+/", "/+"
+        expressions = r"/\.+/", "/+"
         for expression in expressions:
             self._path = sub(expression, Urn.separate, self._path)
 


### PR DESCRIPTION
It fixes this warning that is raised by pytest on projects depending on webdavclient3
```python
    webdav3/urn.py:11: DeprecationWarning: invalid escape sequence '\.'
        expressions = "/\.+/", "/+"
```