### PR TITLE
Allow basic authorization with empty password

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -212,8 +212,7 @@ class Client(object):
             method=self.requests[action],
             url=self.get_url(path),
             auth=(self.webdav.login, self.webdav.password) if (not self.webdav.token and not self.session.auth)
-                                                              and (
-                                                                          self.webdav.login and self.webdav.password) else None,
+                                                              and self.webdav.login else None,
             headers=self.get_headers(action, headers_ext),
             timeout=self.timeout,
             cert=(self.webdav.cert_path, self.webdav.key_path) if (


### PR DESCRIPTION
This fixes the issue that I ran into, trying to access a NextCloud public share. According to [documentation](https://docs.nextcloud.com/server/20/user_manual/en/files/access_webdav.html#accessing-public-shares-over-webdav), when accessing a public share, you need to use the share token as username, and no password is required.

Because of this check, basic authorization wasn't used when empty password is specified, and I was getting a `401 NotAuthenticated` exception. I could work around the bug setting a random password, but I feel like a proper fix is in order.