### PR TITLE
fix: Modify the status code detection range of the `check` function to 2xx

### DIFF
--- a/webdav3/client.py
+++ b/webdav3/client.py
@@ -345,7 +345,8 @@ class Client(object):
         except RemoteResourceNotFound:
             return False
 
-        if int(response.status_code) == 200:
+        # Some WebDAV servers respond with status codes other than 200, such as 207
+        if 200 <= response.status_code < 300:
             return True
         return False
 


### PR DESCRIPTION
Hello! I recently used webdav-client-python-3 to connect to my WebDAV service provider, but I always encounter issues when creating new folders.

After tracing and debugging in the IDE, I found that the `Client.check()` function checks the server status before executing modifications. The `Client.check()` function considers a 200 status code as correct, but my WebDAV service provider returns a 207 status code, which should also be considered correct. In fact, all 2xx status codes should be considered correct.

I made some simple modifications to the code, enabling the `Client.check()` function to correctly handle all 2xx status codes.

<img width="1920" height="930" alt="image" src="https://github.com/user-attachments/assets/e394834d-e800-4288-be71-7b4022d183c8" />

